### PR TITLE
Use Builder jar output by adding BundleGenerator as doLast() action

### DIFF
--- a/src/integTest/groovy/org/dm/gradle/plugins/bundle/BundlePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/org/dm/gradle/plugins/bundle/BundlePluginIntegrationSpec.groovy
@@ -30,6 +30,7 @@ class BundlePluginIntegrationSpec extends Specification {
         def javaSrc = resolve(projectDir, 'src/main/java/org/foo/bar')
         javaSrc.mkdirs()
         resolve(javaSrc, 'TestActivator.java').write getClass().classLoader.getResource('TestActivator.java').text
+        resolve(javaSrc, 'TestComponent.java').write getClass().classLoader.getResource('TestComponent.java').text
         resolve(javaSrc, 'More.java').write 'package org.foo.bar;\n class More {}'
     }
 
@@ -258,6 +259,16 @@ class BundlePluginIntegrationSpec extends Specification {
         then:
         jarContains resource
     }
+	
+	@Issue(13)
+	def "Supports -dsannotations directive"() {
+		when:
+		buildScript.append '\nbundle { instructions << ["-dsannotations": "*"] }'
+		executeGradleCommand 'clean jar'
+
+		then:
+		jarContains 'OSGI-INF/org.foo.bar.TestComponent.xml'
+	}
 
     private static File createTempDir() {
         def temp = resolve(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString())

--- a/src/integTest/resources/TestComponent.java
+++ b/src/integTest/resources/TestComponent.java
@@ -1,0 +1,10 @@
+package org.foo.bar;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	immediate = true,
+	service = String.class
+)
+public class TestComponent {
+}

--- a/src/integTest/resources/build.test
+++ b/src/integTest/resources/build.test
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
     compile 'org.eclipse:osgi:3.9.1-v20130814-1242'
+    compile 'org.osgi:org.osgi.compendium:5.0.0'
 }
 
 bundle {

--- a/src/main/groovy/org/dm/gradle/plugins/bundle/BundlePlugin.groovy
+++ b/src/main/groovy/org/dm/gradle/plugins/bundle/BundlePlugin.groovy
@@ -24,7 +24,7 @@ class BundlePlugin implements Plugin<Project> {
                 def jarBuilderFactory = new JarBuilderFactoryDecorator(
                         jarTask, project.bundle.jarBuilderFactory)
 
-                actions = [new BundleGenerator(jarBuilderFactory)]
+                doLast(new BundleGenerator(jarBuilderFactory))
                 manifest = new ManifestSubstitute(jarBuilderFactory, manifest)
             }
         }


### PR DESCRIPTION
I verified that using the `actions = [new BundleGenerator(...]` method was not getting called and then the Builder()'s jar output was not being used.

My suggested fix was to add the BundleGenerator action to jarTask via doLast() and then also I added an integration test to ensure that the DS annotations generated classes are getting included in the jar.  Also, this fix seems to have fixed 3 other failing integration tests... at least on my local linux build.
