### PR TITLE
Use same gradle binary in integTest as outer gradle process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ task integTest(type: Test, dependsOn: classes) {
     reports.html.destination = file("$buildDir/reports/integTests")
     reports.junitXml.destination = file("$buildDir/integTest-results")
     binResultsDir = file("${reports.junitXml.destination}/binary/integTest")
+    systemProperty "gradle.home", project.getGradle().getGradleHomeDir()
 }
 
 check.dependsOn integTest

--- a/src/integTest/groovy/org/dm/gradle/plugins/bundle/BundlePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/org/dm/gradle/plugins/bundle/BundlePluginIntegrationSpec.groovy
@@ -17,6 +17,8 @@ class BundlePluginIntegrationSpec extends Specification {
     File projectDir = createTempDir()
     @Shared
     File buildScript = resolve(projectDir, 'build.gradle')
+    @Shared
+    String gradleHome = System.getProperty("gradle.home")
     String stdout, stderr, jarName
 
     void setupSpec() {
@@ -295,7 +297,7 @@ class BundlePluginIntegrationSpec extends Specification {
 
     private def executeGradleCommand(cmd) {
 		def command = isWindows() ? "cmd /c " : ""
-		command += "gradle $cmd -b $projectDir/build.gradle"
+		command += "${gradleHome}/bin/gradle $cmd -b $projectDir/build.gradle"
 		
 		def out = new StringBuilder()
 		def err = new StringBuilder()


### PR DESCRIPTION
On my system gradle-2.0 is the default but I also have gradle-1.12.  But when I use gradle-1.12 binary to run the build, the integTests were invoking the 'gradle' process which was using the system default 2.0.  This change makes it so the same gradle that is executing the build will also be used to execute the integration tests.
