### PR TITLE
Added unit test for jar.actions property setting

### DIFF
--- a/src/integTest/groovy/org/dm/gradle/plugins/bundle/BundlePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/org/dm/gradle/plugins/bundle/BundlePluginIntegrationSpec.groovy
@@ -280,6 +280,15 @@ class BundlePluginIntegrationSpec extends Specification {
         manifestContains 'Service-Component: OSGI-INF/org.foo.bar.TestComponent.xml'
         jarContains 'OSGI-INF/org.foo.bar.TestComponent.xml'
     }
+
+	def "jar task actions only contains bundle generator action"() {
+		when:
+		buildScript.append "task actionscheck { doLast { println jar.actions.size() + \" \" + jar.actions[0].@action.getClass().getSimpleName() } }"
+		executeGradleCommand 'actionscheck'
+
+		then:
+		stdout =~ /1 BundleGenerator/
+	}
     
     private static File createTempDir() {
         def temp = resolve(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString())


### PR DESCRIPTION
With regards to gradle-2.0 support #16 first I'd like to add an integTest for the jar.actions() setting.  In existing plugin the actions = [new BundleGenerator()] does correctly reset the actions list from 3 built-in actions to just the one bundleGenerator action as shown in this spec.

This integration test is in preparation for trying to work on gradle-2.0 support.
