### PR TITLE
Release jars after building jar file.

### DIFF
--- a/src/main/groovy/org/dm/gradle/plugins/bundle/JarBuilder.groovy
+++ b/src/main/groovy/org/dm/gradle/plugins/bundle/JarBuilder.groovy
@@ -90,27 +90,28 @@ class JarBuilder {
     }
 
     private def build() {
-        def builder = new Builder()
-        if (builder.bundleVersion == null) {
-            builder.bundleVersion = version
+        new Builder().withCloseable { builder ->
+            if (builder.bundleVersion == null) {
+                builder.bundleVersion = version
+            }
+
+            if (builder.bundleSymbolicName == null) {
+                builder.bundleSymbolicName = name
+            }
+
+            builder.trace = trace
+            builder.base = base
+            builder.properties = properties as Properties
+            builder.sourcepath = sourcepath as File[]
+            builder.setClasspath classpath as File[]
+            builder.addClasspath resources as Collection<File>
+            addToResources builder, resources
+
+            traceClasspath(builder)
+            def jar = builder.build()
+            traceErrors(builder)
+            jar
         }
-
-        if (builder.bundleSymbolicName == null) {
-            builder.bundleSymbolicName = name
-        }
-
-        builder.trace = trace
-        builder.base = base
-        builder.properties = properties as Properties
-        builder.sourcepath = sourcepath as File[]
-        builder.setClasspath classpath as File[]
-        builder.addClasspath resources as Collection<File>
-        addToResources builder, resources
-
-        traceClasspath(builder)
-        def jar = builder.build()
-        traceErrors(builder)
-        jar
     }
 
     private static addToResources(builder, files) {


### PR DESCRIPTION
This is primary a problem under windows in combination with the gradle daemon.
The daemon holds the file handles to all files of the runtime configuration as the Builders close method is not called.
To make this fully working there is also a neccessary change in the bndlib (see https://github.com/bndtools/bnd/pull/1298). So an update to a new version is required as soon as the bndlib is updated.